### PR TITLE
Persist decklist and options

### DIFF
--- a/TASK.MD
+++ b/TASK.MD
@@ -1,0 +1,3 @@
+# Task
+
+persist decklist and options to localstorage. Make it so the user will always find the last decklist uploaded and the last options selected upon starting a new session.


### PR DESCRIPTION
persist decklist and options to localstorage. Make it so the user will always find the last decklist uploaded and the last options selected upon starting a new session.