### PR TITLE
Support for exact card versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# netlify
+.netlify

--- a/DECK-FORMATS.MD
+++ b/DECK-FORMATS.MD
@@ -4,7 +4,7 @@ List of supported deck formats by site / source
 
 ## Table of Contents
 
-- [Moxfield.com](#mofielcomdontg)
+- [Moxfield](#moxfield)
     - [1. Copy for Moxfield (Exact set + card number)](#1-copy-for-moxfield-exact-set--card-number)
     - [2. Copy for Arena](#2-copy-for-arena)
     - [3. Copy for MTGO](#3-copy-for-mtgo)
@@ -16,14 +16,22 @@ List of supported deck formats by site / source
     - [3. .csv file export](#3-csv-file-export)
 - [Magic Arena](#magic-arena)
     - [1. Default export](#1-default-export)
+- [Mtggoldfish](#mtggoldfish)
+    - [1. Text file (default)](#1-text-file-default)
+    - [2. Exact card versions (tabletop)](#2-exact-card-versions-tabletop)
+    - [3. Exact card versions (MTG Arena)](#3-exact-card-versions-mtg-arena)
+    - [4. Exact card versions (Magic Online)](#4-exact-card-versions-magic-online)
+    - [5. Magic Online .dek](#5-magic-online-dek)
 
-## Mofield.com
+## Moxfield
 
 ### 1. Copy for Moxfield (Exact set + card number)
 
-```
+---
+
 60 CARD
 
+```
 4 Abhorrent Oculus (PDSK) 42p
 4 Archon of Cruelty (MH2) 342
 1 Blood Crypt (RNA) 245
@@ -59,9 +67,11 @@ SIDEBOARD:
 1 Surgical Extraction (OTP) 19
 ```
 
-```
+---
+
 COMMANDER
 
+```
 1 Juri, Master of the Revue (MUL) 46
 1 Academy Manufactor (MKC) 221
 1 Arcane Signet (DRC) 52
@@ -154,9 +164,11 @@ COMMANDER
 
 ### 2. Copy for Arena
 
-```
+---
+
 60 CARD
 
+```
 About
 Name Grixis Reanimator
 
@@ -193,9 +205,11 @@ Sideboard
 1 Surgical Extraction
 ```
 
-```
+---
+
 COMMANDER
 
+```
 About
 Name Juri, Master of the Revue
 
@@ -291,9 +305,11 @@ Deck
 
 ### 3. Copy for MTGO
 
-```
+---
+
 60 CARD
 
+```
 4 Abhorrent Oculus
 4 Archon of Cruelty
 1 Blood Crypt
@@ -329,9 +345,11 @@ SIDEBOARD:
 1 Surgical Extraction
 ```
 
-```
+---
+
 COMMANDER
 
+```
 1 Academy Manufactor
 1 Arcane Signet
 1 Arid Mesa
@@ -435,9 +453,11 @@ Same as [Copy for MTGO](#3-copy-for-mtgo)
 
 ### 1. .dek file export
 
-```
+---
+
 60 CARD
 
+```
 <?xml version="1.0" encoding="utf-8"?>
 <Deck xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NetDeckID>0</NetDeckID>
@@ -477,9 +497,11 @@ Same as [Copy for MTGO](#3-copy-for-mtgo)
 </Deck>
 ```
 
-```
+---
+
 COMMANDER
 
+```
 <?xml version="1.0" encoding="utf-8"?>
 <Deck xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <NetDeckID>0</NetDeckID>
@@ -577,9 +599,11 @@ COMMANDER
 
 ### 2. .txt file export
 
-```
+---
+
 60 CARD
 
+```
 4 Deadly Dispute
 4 Drossforge Bridge
 2 Rakdos Carnarium
@@ -614,9 +638,11 @@ COMMANDER
 
 ```
 
-```
+---
+
 COMMANDER
 
+```
 1 Academy Manufactor
 1 Arcane Signet
 1 Arid Mesa
@@ -712,9 +738,11 @@ COMMANDER
 
 ### 3. .csv file export
 
-```
+---
+
 60 CARD
 
+```
 Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
 "Mountain",2,83561,Land,ZNR,277/280,No,No,0
 "Plains",3,83543,Land,ZNR,268/280,No,No,0
@@ -758,9 +786,11 @@ Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
 
 ```
 
-```
+---
+
 COMMANDER
 
+```
 Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
 "Academy Manufactor",1,90819,Rare,MH2,219/303,No,No,0
 "Arcane Signet",1,78722,Common,ELD,331,No,No,0
@@ -859,9 +889,11 @@ Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
 
 ### 1. default export
 
-```
+---
+
 60 CARD
 
+```
 Deck
 4 Yawgmoth, Thran Physician (MH1) 116
 1 Swamp (LTR) 267
@@ -904,9 +936,11 @@ Sideboard
 
 ```
 
-```
+---
+
 COMMANDER
 
+```
 Commander
 1 Juri, Master of the Revue (MUL) 111
 
@@ -996,3 +1030,335 @@ Deck
 1 Zulaport Cutthroat (BFZ) 126
 
 ```
+
+## Mtggoldfish
+
+### 1. Text file (default)
+
+---
+
+60 CARD
+
+Same as [MTGO .txt file export](#2-txt-file-export).
+
+---
+
+COMMANDER
+
+```
+1 Abandoned Air Temple
+1 Anointed Peacekeeper
+1 Aven Interrupter
+1 Benevolent Bodyguard
+1 Castle Ardenvale
+1 Cid, Freeflier Pilot
+1 City of Traitors
+1 Cloud, Midgar Mercenary
+1 Crystal Vein
+1 Curious Farm Animals
+1 Drannith Magistrate
+1 Dust Bowl
+1 Eiganjo Castle
+1 Eiganjo, Seat of the Empire
+1 Elite Spellbinder
+1 Ephemerate
+1 Esper Sentinel
+1 Ethersworn Canonist
+1 Flickerwisp
+1 Gemstone Caverns
+1 Ghost Vacuum
+1 Gingerbrute
+1 Giver of Runes
+1 Glimmer Lens
+1 Guide of Souls
+1 Hand of Vecna
+1 Helitrooper
+1 Helping Hand
+1 Jolted Awake
+1 Lay Down Arms
+1 Lion Sash
+1 Mana Tithe
+1 Masterwork of Ingenuity
+1 Mother of Runes
+1 Ocelot Pride
+1 On Thin Ice
+1 Oust
+1 Parallax Wave
+1 Phelia, Exuberant Shepherd
+1 Pre-War Formalwear
+1 Puresteel Paladin
+1 Ranger-Captain of Eos
+1 Recruiter of the Guard
+1 Reverent Mantra
+1 Sanctifier en-Vec
+1 Seasoned Dungeoneer
+1 Shadowspear
+1 Sigarda's Aid
+1 Skrelv, Defector Mite
+1 Skullclamp
+1 Skyclave Apparition
+30 Snow-Covered Plains
+1 Solitude
+1 Spectacular Spider-Man
+1 Springleaf Drum
+1 Starfield Shepherd
+1 Static Prison
+1 Stoneforge Mystic
+1 Swift Reconfiguration
+1 Sword of Feast and Famine
+1 Sword of Fire and Ice
+1 Swords to Plowshares
+1 Tectonic Edge
+1 Thalia, Guardian of Thraben
+1 Thalia, Heretic Cathar
+1 Umezawa's Jitte
+1 Urza's Saga
+1 Voice of Victory
+1 Warden of the Inner Sky
+1 Winter Moon
+1 Witch Enchanter
+```
+
+### 2. Exact card versions (tabletop)
+
+---
+
+60 CARD
+
+```
+4 Boomerang Basics [TLA]
+4 Burst Lightning [FDN]
+3 Eddymurk Crab [BLB]
+3 Elusive Otter [WOE] (F)
+2 Into the Flood Maw [BLB]
+6 Island <251> [THB]
+2 Multiversal Passage <borderless> [SPM]
+4 Opt [J25]
+4 Riverpyre Verge <borderless> [DFT]
+1 Roaring Furnace/Steaming Sauna [DSK]
+1 Sear [ECL]
+4 Sleight of Hand [WOE]
+4 Slickshot Show-Off [OTJ]
+4 Spirebluff Canal [OTJ] (F)
+4 Steam Vents <Shadowmoor - borderless> [ECL]
+4 Stock Up [DFT]
+4 Stormchaser's Talent [BLB]
+1 Wild Ride [TDM]
+1 Willowrush Verge [DFT]
+
+1 Annul [KHM]
+1 Broadside Barrage [DFT]
+2 Fire Magic [FIN]
+2 Get Out [DSK]
+2 Ral, Crackling Wit [BLB]
+1 Roaring Furnace/Steaming Sauna [DSK]
+1 Sear [ECL]
+2 Soul-Guide Lantern [FDN]
+2 Spell Pierce [XLN]
+1 Torch the Tower [WOE]
+```
+
+---
+
+COMMANDER
+
+```
+1 Abandoned Air Temple [TLA]
+1 Anointed Peacekeeper [DMU]
+1 Aven Interrupter [OTJ]
+1 Benevolent Bodyguard [PLIST]
+1 Castle Ardenvale [TDC]
+1 Cid, Freeflier Pilot [FIC]
+1 City of Traitors [EX]
+1 Cloud, Midgar Mercenary [FIN]
+1 Crystal Vein [6ED]
+1 Curious Farm Animals [TLA]
+1 Drannith Magistrate <Mayor Tong of Chin Village - borderless> [TLE]
+1 Dust Bowl <showcase> [OTP]
+1 Eiganjo Castle [CHK]
+1 Eiganjo, Seat of the Empire [NEO]
+1 Elite Spellbinder [STX]
+1 Ephemerate [MH1]
+1 Esper Sentinel [MH2]
+1 Ethersworn Canonist [ALA]
+1 Flickerwisp [PLIST]
+1 Gemstone Caverns [TSR]
+1 Ghost Vacuum [DSK]
+1 Gingerbrute [J25]
+1 Giver of Runes <retro> [MH2] (FE)
+1 Glimmer Lens [ONC]
+1 Guide of Souls [MH3]
+1 Hand of Vecna [AFR]
+1 Helitrooper [FIC]
+1 Helping Hand [LCI]
+1 Jolted Awake [MH3]
+1 Lay Down Arms [BRO]
+1 Lion Sash [NEO] (F)
+1 Mana Tithe [MB1]
+1 Masterwork of Ingenuity [PIP]
+1 Mother of Runes [DDO]
+1 Ocelot Pride [MH3]
+1 On Thin Ice [MH1]
+1 Oust [DDP]
+1 Parallax Wave [PLIST]
+1 Phelia, Exuberant Shepherd [MH3]
+1 Pre-War Formalwear [PIP]
+1 Puresteel Paladin [FIC]
+1 Ranger-Captain of Eos <Knights of San d'Oria> [FCA]
+1 Recruiter of the Guard [MH3]
+1 Reverent Mantra [MM]
+1 Sanctifier en-Vec [MH2]
+1 Seasoned Dungeoneer <extended> [CLB]
+1 Shadowspear [THB]
+1 Sigarda's Aid <precon> [CMR]
+1 Skrelv, Defector Mite <showcase> [ONE]
+1 Skullclamp [FIC]
+1 Skyclave Apparition [BLC]
+30 Snow-Covered Plains <276> [KHM]
+1 Solitude [MH2]
+1 Spectacular Spider-Man <borderless> [SPM]
+1 Springleaf Drum [ECL]
+1 Starfield Shepherd [EOE]
+1 Static Prison [MH3]
+1 Stoneforge Mystic [WWK]
+1 Swift Reconfiguration <extended> [NEC]
+1 Sword of Feast and Famine [ACR]
+1 Sword of Fire and Ice <BLB Special Guest> [SPG]
+1 Swords to Plowshares [GN3]
+1 Tectonic Edge [M3C]
+1 Thalia, Guardian of Thraben <showcase> [VOW]
+1 Thalia, Heretic Cathar <retro> [INR]
+1 Umezawa's Jitte [PLIST]
+1 Urza's Saga <showcase> [MH2]
+1 Voice of Victory [TDM]
+1 Warden of the Inner Sky [LCI]
+1 Winter Moon [MH3]
+1 Witch Enchanter [MH3]
+```
+
+### 3. Exact card versions (MTG Arena)
+
+---
+
+60 CARD
+
+```
+1 Archenemy's Charm <borderless - surreal space> [EOE] (F)
+2 Bitter Triumph [LCI] (F)
+1 Cavern of Souls <prerelease> [LCI] (F)
+2 Day of Black Sun <prerelease> [TLA] (F)
+2 Deadly Cover-Up <prerelease> [MKM] (F)
+4 Deceit
+3 Doomsday Excruciator [DSK] (F)
+1 Duress <beginner box> [FDN]
+4 Gloomlake Verge <borderless> [DSK] (F)
+2 Harvester of Misery
+2 Insatiable Avarice <prerelease> [OTJ] (F)
+4 Kavaero, Mind-Bitten [OM1]
+1 Malboro [FIN]
+4 Requiting Hex
+4 Restless Reef <prerelease> [LCI] (F)
+1 Shoot the Sheriff [OTJ] (F)
+4 Stock Up [DFT] (F)
+10 Swamp <252> [THB]
+2 Undercity Sewers <prerelease> [MKM] (F)
+4 Watery Grave <borderless - galaxy foil> [EOE] (F)
+2 Winternight Stories <prerelease> [TDM] (F)
+
+1 Annul <promo pack> [EOE] (F)
+1 Cruelclaw's Heist <showcase> [BLB] (F)
+2 Duress <beginner box> [FDN]
+2 Flashfreeze <beginner box> [FDN]
+2 Intimidation Tactics [DFT] (F)
+2 Oildeep Gearhulk <prerelease> [DFT] (F)
+1 Overlord of the Balemurk <Japan Showcase> [DSK]
+2 Quantum Riddler <borderless - surreal space> [EOE] (F)
+1 Soul-Guide Lantern <beginner box> [FDN]
+1 Strategic Betrayal [TDM]
+```
+
+---
+
+COMMANDER
+
+```
+1 Abandoned Air Temple <prerelease> [TLA] (F)
+1 Ademi of the Silkchutes [OM1]
+1 Anointed Peacekeeper <prerelease> [DMU] (F)
+1 Aven Interrupter <prerelease> [OTJ] (F)
+1 Benevolent Bodyguard [EMA] (F)
+1 Castle Ardenvale <planeswalker stamp> [ELD] (F)
+1 Cid, Freeflier Pilot
+1 City of Traitors [TPR] (F)
+1 Cloud, Midgar Mercenary <prerelease> [FIN] (F)
+1 Crystal Vein [C14] (F)
+1 Curious Farm Animals [TLA] (F)
+1 Drannith Magistrate <planeswalker stamp> [IKO] (F)
+1 Dust Bowl <showcase> [OTP] (F)
+1 Eiganjo Castle [CHK] (F)
+1 Eiganjo, Seat of the Empire <prerelease> [NEO] (F)
+1 Elite Spellbinder <planeswalker stamp> [STX] (F)
+1 Ephemerate <japanese> [STA] (FE)
+1 Esper Sentinel [MH2]
+1 Ethersworn Canonist [MMA] (F)
+1 Flickerwisp [C14] (F)
+1 Gemstone Caverns [TSP] (F)
+1 Ghost Vacuum <showcase> [DSK] (F)
+1 Gingerbrute [WOE] (F)
+1 Giver of Runes [MH1]
+1 Glimmer Lens [ONC]
+1 Guide of Souls [MH3] (F)
+1 Hand of Vecna <prerelease> [AFR] (F)
+1 Helitrooper
+1 Helping Hand [LCI] (F)
+1 Jolted Awake <retro> [MH3] (F)
+1 Lay Down Arms <promo pack> [BRO] (F)
+1 Lion Sash <prerelease> [NEO] (F)
+1 Mana Tithe <japanese> [STA] (FE)
+1 Masterwork of Ingenuity [C14] (F)
+1 Mother of Runes [MB1]
+1 Ocelot Pride <retro> [MH3]
+1 On Thin Ice [MH1] (F)
+1 Oust [MB1]
+1 Parallax Wave [VMA] (F)
+1 Phelia, Exuberant Shepherd <foil etched> [MH3] (F)
+1 Pre-War Formalwear
+1 Puresteel Paladin [DPA]
+1 Ranger-Captain of Eos [MH1]
+1 Recruiter of the Guard <borderless> [MH3] (F)
+1 Reverent Mantra [MM] (F)
+1 Sanctifier en-Vec
+1 Seasoned Dungeoneer
+1 Shadowspear <planeswalker stamp> [THB] (F)
+1 Sigarda's Aid [SIR]
+1 Skrelv, Defector Mite <prerelease> [ONE] (F)
+1 Skullclamp [C20]
+1 Skyclave Apparition <planeswalker stamp> [ZNR] (F)
+30 Snow-Covered Plains <277> [KHM] (F)
+1 Solitude
+1 Springleaf Drum <schematics> [BRR] (F)
+1 Starfield Shepherd <promo pack> [EOE]
+1 Static Prison [MH3] (F)
+1 Stoneforge Mystic <OTJ Special Guest> [SPG]
+1 Swift Reconfiguration
+1 Sword of Feast and Famine [MS2]
+1 Sword of Fire and Ice [DST]
+1 Swords to Plowshares [LCC]
+1 Tectonic Edge [MB1]
+1 Thalia, Guardian of Thraben <foil etched> [MUL] (FE)
+1 Thalia, Heretic Cathar [SIR]
+1 Umezawa's Jitte [PRM-GPP] (F)
+1 Urza's Saga
+1 Voice of Victory <prerelease> [TDM] (F)
+1 Warden of the Inner Sky <prerelease> [LCI] (F)
+1 Winter Moon [MH3] (F)
+1 Witch Enchanter [MH3] (F)
+```
+
+### 4. Exact card versions (Magic Online)
+
+same as [Exact card versions (MTG Arena)](#3-exact-card-versions-mtg-arena).
+
+### 5. Magic Online .dek
+
+Same as [.dek file export](#1-dek-file-export) from MTGO, **but the commander is missing the commander-specific annotation**!

--- a/DECK-FORMATS.MD
+++ b/DECK-FORMATS.MD
@@ -1,0 +1,998 @@
+# Supported Deck Formats
+
+List of supported deck formats by site / source
+
+## Table of Contents
+
+- [Moxfield.com](#mofielcomdontg)
+    - [1. Copy for Moxfield (Exact set + card number)](#1-copy-for-moxfield-exact-set--card-number)
+    - [2. Copy for Arena](#2-copy-for-arena)
+    - [3. Copy for MTGO](#3-copy-for-mtgo)
+    - [4. Copy plain text](#4-copy-plain-text)
+    - [5. Download for MTGO](#5-download-for-mtgo)
+- [Magic Online](#magic-online)
+    - [1. .dek file export](#1-dek-file-export)
+    - [2. .txt file export](#2-txt-file-export)
+    - [3. .csv file export](#3-csv-file-export)
+- [Magic Arena](#magic-arena)
+    - [1. Default export](#1-default-export)
+
+## Mofield.com
+
+### 1. Copy for Moxfield (Exact set + card number)
+
+```
+60 CARD
+
+4 Abhorrent Oculus (PDSK) 42p
+4 Archon of Cruelty (MH2) 342
+1 Blood Crypt (RNA) 245
+4 Bloodstained Mire (MH3) 216
+1 Dauthi Voidwalker (TDC) 176
+4 Emperor of Bones (MH3) 90
+4 Faithless Looting (PLST) CM2-96
+4 Fatal Push (PLST) AER-57
+1 Island (J25) 86
+3 Otherworldly Gaze (MKC) 115
+4 Persist (MH2) 400
+4 Polluted Delta (MH3) 224
+4 Psychic Frog (MH3) 199
+1 Raucous Theater (MKM) 266
+2 Scalding Tarn (MM3) 244
+1 Steam Vents (GRN) 257
+2 Swamp (J25) 89
+4 Thoughtseize (THS) 107
+1 Undercity Sewers (MKM) 270
+4 Unearth (2X2) 96
+1 Unmarked Grave (MH2) 106
+2 Watery Grave (GRN) 259
+
+SIDEBOARD:
+1 Abrade (INR) 139
+2 Force of Despair (SLP) 29
+3 Harbinger of the Seas (MH3) 63
+2 Meltdown (MH3) 282
+1 Molten Collapse (LCI) 342
+2 Mystical Dispute (MB2) 31
+2 Nihil Spellbomb (PLST) SOM-187
+1 Pyroclasm (DSK) 149
+1 Surgical Extraction (OTP) 19
+```
+
+```
+COMMANDER
+
+1 Juri, Master of the Revue (MUL) 46
+1 Academy Manufactor (MKC) 221
+1 Arcane Signet (DRC) 52
+1 Arid Mesa (MH2) 244
+1 Bastion of Remembrance (J25) 403
+1 Bitterbloom Bearer (ECL) 88
+1 Bitterblossom (MM2) 71
+1 Blazemire Verge (DSK) 256
+1 Blood Artist (JMP) 206
+1 Blood Crypt (RVR) 397
+1 Bloodghast (PLST) ZEN-83
+1 Bloodstained Mire (KTK) 230
+1 Bloodtithe Harvester (PLST) VOW-232
+1 Bojuka Bog (DSC) 265
+1 Braids, Arisen Nightmare (DMU) 84
+1 Callous Sell-Sword / Burn Together (WOE) 221
+1 Carrion Feeder (MH1) 81
+1 Cauldron Familiar (ELD) 81
+1 Cavalier of Night (PM20) 94p
+1 Chainsaw (DSK) 128
+1 Command Tower (OTC) 280
+1 Corrupted Conviction (OTJ) 84
+1 Deadly Dispute (BLC) 181
+1 Deflecting Swat (C20) 50
+1 Demonic Tutor (CED) 105
+1 Disciple of Bolas (TDC) 178
+1 Dismember (NPH) 57
+1 Dragonskull Summit (XLN) 252
+1 Dreadhorde Invasion (WAR) 86
+1 Erebos, Bleak-Hearted (THB) 93
+1 Evereth, Viceroy of Plunder (J25) 41
+1 Fable of the Mirror-Breaker / Reflection of Kiki-Jiki (NEO) 141
+1 Fabled Passage (M21) 246
+1 Fatal Push (KLR) 84
+1 Final Vengeance (DSK) 99
+1 Fling (JMP) 320
+1 Fountainport (BLB) 253
+1 Goblin Bombardment (WOT) 43
+1 Goldspan Dragon (M3C) 212
+1 Grave Pact (HOP) 28
+1 Greedy Freebooter (LCI) 109
+1 Haunted Ridge (PMID) 263p
+1 Jadar, Ghoulcaller of Nephalia (MID) 108
+1 Kazuul's Fury / Kazuul's Cliffs (ZNR) 146
+1 Krenko, Tin Street Kingpin (WAR) 137
+1 Lord Skitter, Sewer King (WOE) 97
+1 Mana Confluence (JOU) 163
+1 Marionette Apprentice (MH3) 100
+1 Marsh Flats (MH2) 248
+1 Mayhem Devil (EOC) 121
+1 Mirkwood Bats (LTR) 421
+4 Mountain (SNC) 268
+1 Nine-Lives Familiar (FDN) 66
+1 Not Dead After All (WOE) 101
+1 Ophiomancer (TDC) 193
+1 Phyrexian Tower (MH3) 303
+1 Priest of Forgotten Gods (RVR) 90
+1 Rakdos Charm (LCC) 284
+1 Rankle, Master of Pranks (WOC) 116
+1 Raucous Theater (MKM) 266
+1 Reassembling Skeleton (M12) 104
+1 Reflecting Pool (CLB) 358
+1 Scavenger's Talent (BLB) 111
+1 Sephiroth, Fabled SOLDIER / Sephiroth, One-Winged Angel (FIN) 115
+1 Sheoldred / The True Scriptures (MOM) 125
+1 Sheoldred, the Apocalypse (DMU) 107
+1 Sheoldred's Edict (ONE) 108
+1 Sol Ring (LTC) 284
+1 Solemn Simulacrum (SCD) 277
+1 Sulfurous Springs (EOC) 185
+1 Supernatural Stamina (PLST) GN3-62
+10 Swamp (MKM) 282
+1 Talisman of Indulgence (AA1) 23
+1 The Meathook Massacre (INR) 387
+1 Umbral Collar Zealot (EOE) 123
+1 Undying Malice (FDN) 528
+1 Urabrask's Forge (ONE) 153
+1 Urborg, Tomb of Yawgmoth (PLST) UMA-254
+1 Vampiric Tutor (DMR) 314
+1 Vengeful Bloodwitch (FDN) 76
+1 Village Rites (J22) 486
+1 Viscera Seer (TDC) 199
+1 Warren Soultrader (MH3) 110
+1 Westvale Abbey / Ormendahl, Profane Prince (SOI) 281
+1 Witch's Oven (ELD) 237
+1 Woe Strider (TDC) 201
+1 Yawgmoth, Thran Physician (DMR) 315
+1 Zulaport Cutthroat (BFZ) 126
+```
+
+### 2. Copy for Arena
+
+```
+60 CARD
+
+About
+Name Grixis Reanimator
+
+Deck
+4 Abhorrent Oculus
+1 Blood Crypt
+4 Bloodstained Mire
+1 Dauthi Voidwalker
+4 Emperor of Bones
+4 Faithless Looting
+4 Fatal Push
+1 Island
+3 Otherworldly Gaze
+4 Persist
+4 Polluted Delta
+4 Psychic Frog
+1 Raucous Theater
+2 Scalding Tarn
+1 Steam Vents
+2 Swamp
+4 Thoughtseize
+1 Undercity Sewers
+4 Unearth
+1 Unmarked Grave
+2 Watery Grave
+
+Sideboard
+1 Abrade
+3 Harbinger of the Seas
+2 Meltdown
+1 Molten Collapse
+2 Mystical Dispute
+1 Pyroclasm
+1 Surgical Extraction
+```
+
+```
+COMMANDER
+
+About
+Name Juri, Master of the Revue
+
+Commander
+1 Juri, Master of the Revue
+
+Deck
+1 Academy Manufactor
+1 Arcane Signet
+1 Arid Mesa
+1 Bastion of Remembrance
+1 Bitterbloom Bearer
+1 Bitterblossom
+1 Blazemire Verge
+1 Blood Artist
+1 Blood Crypt
+1 Bloodghast
+1 Bloodstained Mire
+1 Bloodtithe Harvester
+1 Bojuka Bog
+1 Braids, Arisen Nightmare
+1 Callous Sell-Sword
+1 Cauldron Familiar
+1 Cavalier of Night
+1 Chainsaw
+1 Command Tower
+1 Corrupted Conviction
+1 Deadly Dispute
+1 Deflecting Swat
+1 Demonic Tutor
+1 Disciple of Bolas
+1 Dismember
+1 Dragonskull Summit
+1 Dreadhorde Invasion
+1 Erebos, Bleak-Hearted
+1 Evereth, Viceroy of Plunder
+1 Fable of the Mirror-Breaker
+1 Fabled Passage
+1 Fatal Push
+1 Final Vengeance
+1 Fling
+1 Fountainport
+1 Goblin Bombardment
+1 Goldspan Dragon
+1 Grave Pact
+1 Greedy Freebooter
+1 Haunted Ridge
+1 Jadar, Ghoulcaller of Nephalia
+1 Kazuul's Fury
+1 Krenko, Tin Street Kingpin
+1 Lord Skitter, Sewer King
+1 Mana Confluence
+1 Marionette Apprentice
+1 Marsh Flats
+1 Mayhem Devil
+1 Mirkwood Bats
+4 Mountain
+1 Nine-Lives Familiar
+1 Not Dead After All
+1 Ophiomancer
+1 Phyrexian Tower
+1 Priest of Forgotten Gods
+1 Rakdos Charm
+1 Rankle, Master of Pranks
+1 Raucous Theater
+1 Reassembling Skeleton
+1 Reflecting Pool
+1 Scavenger's Talent
+1 Sephiroth, Fabled SOLDIER
+1 Sheoldred
+1 Sheoldred, the Apocalypse
+1 Sheoldred's Edict
+1 Sol Ring
+1 Solemn Simulacrum
+1 Sulfurous Springs
+1 Supernatural Stamina
+10 Swamp
+1 Talisman of Indulgence
+1 The Meathook Massacre
+1 Umbral Collar Zealot
+1 Undying Malice
+1 Urabrask's Forge
+1 Urborg, Tomb of Yawgmoth
+1 Vengeful Bloodwitch
+1 Village Rites
+1 Warren Soultrader
+1 Westvale Abbey
+1 Witch's Oven
+1 Woe Strider
+1 Yawgmoth, Thran Physician
+1 Zulaport Cutthroat
+```
+
+### 3. Copy for MTGO
+
+```
+60 CARD
+
+4 Abhorrent Oculus
+4 Archon of Cruelty
+1 Blood Crypt
+4 Bloodstained Mire
+1 Dauthi Voidwalker
+4 Emperor of Bones
+4 Faithless Looting
+4 Fatal Push
+1 Island
+3 Otherworldly Gaze
+4 Persist
+4 Polluted Delta
+4 Psychic Frog
+1 Raucous Theater
+2 Scalding Tarn
+1 Steam Vents
+2 Swamp
+4 Thoughtseize
+1 Undercity Sewers
+4 Unearth
+1 Unmarked Grave
+2 Watery Grave
+
+SIDEBOARD:
+1 Abrade
+2 Force of Despair
+3 Harbinger of the Seas
+2 Meltdown
+1 Molten Collapse
+2 Mystical Dispute
+2 Nihil Spellbomb
+1 Pyroclasm
+1 Surgical Extraction
+```
+
+```
+COMMANDER
+
+1 Academy Manufactor
+1 Arcane Signet
+1 Arid Mesa
+1 Bastion of Remembrance
+1 Bitterbloom Bearer
+1 Bitterblossom
+1 Blazemire Verge
+1 Blood Artist
+1 Blood Crypt
+1 Bloodghast
+1 Bloodstained Mire
+1 Bloodtithe Harvester
+1 Bojuka Bog
+1 Braids, Arisen Nightmare
+1 Callous Sell-Sword
+1 Carrion Feeder
+1 Cauldron Familiar
+1 Cavalier of Night
+1 Chainsaw
+1 Command Tower
+1 Corrupted Conviction
+1 Deadly Dispute
+1 Deflecting Swat
+1 Demonic Tutor
+1 Disciple of Bolas
+1 Dismember
+1 Dragonskull Summit
+1 Dreadhorde Invasion
+1 Erebos, Bleak-Hearted
+1 Evereth, Viceroy of Plunder
+1 Fable of the Mirror-Breaker
+1 Fabled Passage
+1 Fatal Push
+1 Final Vengeance
+1 Fling
+1 Fountainport
+1 Goblin Bombardment
+1 Goldspan Dragon
+1 Grave Pact
+1 Greedy Freebooter
+1 Haunted Ridge
+1 Jadar, Ghoulcaller of Nephalia
+1 Kazuul's Fury
+1 Krenko, Tin Street Kingpin
+1 Lord Skitter, Sewer King
+1 Mana Confluence
+1 Marionette Apprentice
+1 Marsh Flats
+1 Mayhem Devil
+1 Mirkwood Bats
+4 Mountain
+1 Nine-Lives Familiar
+1 Not Dead After All
+1 Ophiomancer
+1 Phyrexian Tower
+1 Priest of Forgotten Gods
+1 Rakdos Charm
+1 Rankle, Master of Pranks
+1 Raucous Theater
+1 Reassembling Skeleton
+1 Reflecting Pool
+1 Scavenger's Talent
+1 Sephiroth, Fabled SOLDIER
+1 Sheoldred
+1 Sheoldred, the Apocalypse
+1 Sheoldred's Edict
+1 Sol Ring
+1 Solemn Simulacrum
+1 Sulfurous Springs
+1 Supernatural Stamina
+10 Swamp
+1 Talisman of Indulgence
+1 The Meathook Massacre
+1 Umbral Collar Zealot
+1 Undying Malice
+1 Urabrask's Forge
+1 Urborg, Tomb of Yawgmoth
+1 Vampiric Tutor
+1 Vengeful Bloodwitch
+1 Village Rites
+1 Viscera Seer
+1 Warren Soultrader
+1 Westvale Abbey
+1 Witch's Oven
+1 Woe Strider
+1 Yawgmoth, Thran Physician
+1 Zulaport Cutthroat
+
+1 Juri, Master of the Revue
+```
+
+### 4. Copy plain text
+
+Same as [Copy for MTGO](#3-copy-for-mtgo)
+
+### 5. Download for MTGO
+
+Same as [Copy for MTGO](#3-copy-for-mtgo)
+
+## Magic Online
+
+### 1. .dek file export
+
+```
+60 CARD
+
+<?xml version="1.0" encoding="utf-8"?>
+<Deck xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NetDeckID>0</NetDeckID>
+  <PreconstructedDeckID>0</PreconstructedDeckID>
+  <Cards CatID="83555" Quantity="1" Sideboard="false" Name="Swamp" Annotation="0" />
+  <Cards CatID="83567" Quantity="2" Sideboard="false" Name="Forest" Annotation="0" />
+  <Cards CatID="66259" Quantity="4" Sideboard="false" Name="Wall of Roots" Annotation="0" />
+  <Cards CatID="46246" Quantity="1" Sideboard="false" Name="Dryad Arbor" Annotation="0" />
+  <Cards CatID="30084" Quantity="2" Sideboard="false" Name="Twilight Mire" Annotation="0" />
+  <Cards CatID="90901" Quantity="4" Sideboard="false" Name="Verdant Catacombs" Annotation="0" />
+  <Cards CatID="43153" Quantity="4" Sideboard="false" Name="Strangleroot Geist" Annotation="0" />
+  <Cards CatID="43457" Quantity="2" Sideboard="false" Name="Young Wolf" Annotation="0" />
+  <Cards CatID="44105" Quantity="1" Sideboard="false" Name="Blood Artist" Annotation="0" />
+  <Cards CatID="53742" Quantity="4" Sideboard="false" Name="Chord of Calling" Annotation="0" />
+  <Cards CatID="35513" Quantity="3" Sideboard="false" Name="Khalni Garden" Annotation="0" />
+  <Cards CatID="61460" Quantity="4" Sideboard="false" Name="Eldritch Evolution" Annotation="0" />
+  <Cards CatID="64000" Quantity="1" Sideboard="false" Name="Hapatra, Vizier of Poisons" Annotation="0" />
+  <Cards CatID="46507" Quantity="2" Sideboard="false" Name="Overgrown Tomb" Annotation="0" />
+  <Cards CatID="71904" Quantity="4" Sideboard="false" Name="Arboreal Grazer" Annotation="0" />
+  <Cards CatID="72604" Quantity="4" Sideboard="false" Name="Yawgmoth, Thran Physician" Annotation="0" />
+  <Cards CatID="72858" Quantity="2" Sideboard="false" Name="Nurturing Peatland" Annotation="0" />
+  <Cards CatID="90709" Quantity="2" Sideboard="false" Name="Ignoble Hierarch" Annotation="0" />
+  <Cards CatID="90781" Quantity="4" Sideboard="false" Name="Grist, the Hunger Tide" Annotation="0" />
+  <Cards CatID="34622" Quantity="2" Sideboard="false" Name="Misty Rainforest" Annotation="0" />
+  <Cards CatID="91295" Quantity="1" Sideboard="false" Name="Endurance" Annotation="0" />
+  <Cards CatID="98135" Quantity="2" Sideboard="false" Name="Boseiju, Who Endures" Annotation="0" />
+  <Cards CatID="23206" Quantity="2" Sideboard="false" Name="Golgari Rot Farm" Annotation="0" />
+  <Cards CatID="78458" Quantity="1" Sideboard="false" Name="Gilded Goose" Annotation="0" />
+  <Cards CatID="50256" Quantity="3" Sideboard="true" Name="Thoughtseize" Annotation="0" />
+  <Cards CatID="62689" Quantity="2" Sideboard="true" Name="Fatal Push" Annotation="0" />
+  <Cards CatID="91309" Quantity="2" Sideboard="true" Name="Force of Vigor" Annotation="0" />
+  <Cards CatID="39734" Quantity="1" Sideboard="true" Name="Phyrexian Metamorph" Annotation="0" />
+  <Cards CatID="91295" Quantity="3" Sideboard="true" Name="Endurance" Annotation="0" />
+  <Cards CatID="105018" Quantity="1" Sideboard="true" Name="Haywire Mite" Annotation="0" />
+  <Cards CatID="106669" Quantity="1" Sideboard="true" Name="The Filigree Sylex" Annotation="0" />
+  <Cards CatID="110090" Quantity="1" Sideboard="true" Name="Pile On" Annotation="0" />
+</Deck>
+```
+
+```
+COMMANDER
+
+<?xml version="1.0" encoding="utf-8"?>
+<Deck xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <NetDeckID>0</NetDeckID>
+  <PreconstructedDeckID>0</PreconstructedDeckID>
+  <Cards CatID="90819" Quantity="1" Sideboard="false" Name="Academy Manufactor" Annotation="0" />
+  <Cards CatID="78722" Quantity="1" Sideboard="false" Name="Arcane Signet" Annotation="0" />
+  <Cards CatID="90869" Quantity="1" Sideboard="false" Name="Arid Mesa" Annotation="0" />
+  <Cards CatID="80155" Quantity="1" Sideboard="false" Name="Bastion of Remembrance" Annotation="0" />
+  <Cards CatID="146563" Quantity="1" Sideboard="false" Name="Bitterbloom Bearer" Annotation="0" />
+  <Cards CatID="101622" Quantity="1" Sideboard="false" Name="Bitterblossom" Annotation="0" />
+  <Cards CatID="130643" Quantity="1" Sideboard="false" Name="Blazemire Verge" Annotation="0" />
+  <Cards CatID="81479" Quantity="1" Sideboard="false" Name="Village Rites" Annotation="0" />
+  <Cards CatID="146917" Quantity="1" Sideboard="false" Name="Blood Crypt" Annotation="0" />
+  <Cards CatID="83555" Quantity="10" Sideboard="false" Name="Swamp" Annotation="0" />
+  <Cards CatID="126451" Quantity="1" Sideboard="false" Name="Bloodstained Mire" Annotation="0" />
+  <Cards CatID="94832" Quantity="1" Sideboard="false" Name="Bloodtithe Harvester" Annotation="0" />
+  <Cards CatID="142435" Quantity="1" Sideboard="false" Name="Bojuka Bog" Annotation="0" />
+  <Cards CatID="102644" Quantity="1" Sideboard="false" Name="Braids, Arisen Nightmare" Annotation="0" />
+  <Cards CatID="116788" Quantity="1" Sideboard="false" Name="Callous Sell-Sword" Annotation="0" />
+  <Cards CatID="83561" Quantity="4" Sideboard="false" Name="Mountain" Annotation="0" />
+  <Cards CatID="78274" Quantity="1" Sideboard="false" Name="Cauldron Familiar" Annotation="0" />
+  <Cards CatID="73087" Quantity="1" Sideboard="false" Name="Cavalier of Night" Annotation="0" />
+  <Cards CatID="130387" Quantity="1" Sideboard="false" Name="Chainsaw" Annotation="0" />
+  <Cards CatID="78726" Quantity="1" Sideboard="false" Name="Command Tower" Annotation="0" />
+  <Cards CatID="124079" Quantity="1" Sideboard="false" Name="Corrupted Conviction" Annotation="0" />
+  <Cards CatID="91690" Quantity="1" Sideboard="false" Name="Deadly Dispute" Annotation="0" />
+  <Cards CatID="114655" Quantity="1" Sideboard="false" Name="Deflecting Swat" Annotation="0" />
+  <Cards CatID="115399" Quantity="1" Sideboard="false" Name="Demonic Tutor" Annotation="0" />
+  <Cards CatID="138293" Quantity="1" Sideboard="false" Name="Disciple of Bolas" Annotation="0" />
+  <Cards CatID="57330" Quantity="1" Sideboard="false" Name="Dismember" Annotation="0" />
+  <Cards CatID="65534" Quantity="1" Sideboard="false" Name="Dragonskull Summit" Annotation="0" />
+  <Cards CatID="71778" Quantity="1" Sideboard="false" Name="Dreadhorde Invasion" Annotation="0" />
+  <Cards CatID="79310" Quantity="1" Sideboard="false" Name="Erebos, Bleak-Hearted" Annotation="0" />
+  <Cards CatID="132762" Quantity="1" Sideboard="false" Name="Evereth, Viceroy of Plunder" Annotation="0" />
+  <Cards CatID="97210" Quantity="1" Sideboard="false" Name="Fable of the Mirror-Breaker" Annotation="0" />
+  <Cards CatID="129749" Quantity="1" Sideboard="false" Name="Fabled Passage" Annotation="0" />
+  <Cards CatID="62689" Quantity="1" Sideboard="false" Name="Fatal Push" Annotation="0" />
+  <Cards CatID="130329" Quantity="1" Sideboard="false" Name="Final Vengeance" Annotation="0" />
+  <Cards CatID="78378" Quantity="1" Sideboard="false" Name="Fling" Annotation="0" />
+  <Cards CatID="129751" Quantity="1" Sideboard="false" Name="Fountainport" Annotation="0" />
+  <Cards CatID="90981" Quantity="1" Sideboard="false" Name="Goblin Bombardment" Annotation="0" />
+  <Cards CatID="87613" Quantity="1" Sideboard="false" Name="Goldspan Dragon" Annotation="0" />
+  <Cards CatID="115429" Quantity="1" Sideboard="false" Name="Grave Pact" Annotation="0" />
+  <Cards CatID="118024" Quantity="1" Sideboard="false" Name="Greedy Freebooter" Annotation="0" />
+  <Cards CatID="93536" Quantity="1" Sideboard="false" Name="Haunted Ridge" Annotation="0" />
+  <Cards CatID="93176" Quantity="1" Sideboard="false" Name="Jadar, Ghoulcaller of Nephalia" Annotation="0" />
+  <Cards CatID="83265" Quantity="1" Sideboard="false" Name="Kazuul's Fury" Annotation="0" />
+  <Cards CatID="71880" Quantity="1" Sideboard="false" Name="Krenko, Tin Street Kingpin" Annotation="0" />
+  <Cards CatID="116510" Quantity="1" Sideboard="false" Name="Lord Skitter, Sewer King" Annotation="0" />
+  <Cards CatID="86356" Quantity="1" Sideboard="false" Name="Mana Confluence" Annotation="0" />
+  <Cards CatID="126217" Quantity="1" Sideboard="false" Name="Marionette Apprentice" Annotation="0" />
+  <Cards CatID="90877" Quantity="1" Sideboard="false" Name="Marsh Flats" Annotation="0" />
+  <Cards CatID="72014" Quantity="1" Sideboard="false" Name="Mayhem Devil" Annotation="0" />
+  <Cards CatID="112100" Quantity="1" Sideboard="false" Name="Mirkwood Bats" Annotation="0" />
+  <Cards CatID="60805" Quantity="1" Sideboard="false" Name="Carrion Feeder" Annotation="0" />
+  <Cards CatID="133700" Quantity="1" Sideboard="false" Name="Nine-Lives Familiar" Annotation="0" />
+  <Cards CatID="116518" Quantity="1" Sideboard="false" Name="Not Dead After All" Annotation="0" />
+  <Cards CatID="125963" Quantity="1" Sideboard="false" Name="Ophiomancer" Annotation="0" />
+  <Cards CatID="126017" Quantity="1" Sideboard="false" Name="Phyrexian Tower" Annotation="0" />
+  <Cards CatID="71166" Quantity="1" Sideboard="false" Name="Priest of Forgotten Gods" Annotation="0" />
+  <Cards CatID="142387" Quantity="1" Sideboard="false" Name="Rakdos Charm" Annotation="0" />
+  <Cards CatID="78320" Quantity="1" Sideboard="false" Name="Rankle, Master of Pranks" Annotation="0" />
+  <Cards CatID="122024" Quantity="1" Sideboard="false" Name="Raucous Theater" Annotation="0" />
+  <Cards CatID="133390" Quantity="1" Sideboard="false" Name="Reassembling Skeleton" Annotation="0" />
+  <Cards CatID="100754" Quantity="1" Sideboard="false" Name="Reflecting Pool" Annotation="0" />
+  <Cards CatID="129467" Quantity="1" Sideboard="false" Name="Scavenger's Talent" Annotation="0" />
+  <Cards CatID="141159" Quantity="1" Sideboard="false" Name="Sephiroth, Fabled SOLDIER" Annotation="0" />
+  <Cards CatID="110096" Quantity="1" Sideboard="false" Name="Sheoldred" Annotation="0" />
+  <Cards CatID="102690" Quantity="1" Sideboard="false" Name="Sheoldred, the Apocalypse" Annotation="0" />
+  <Cards CatID="106431" Quantity="1" Sideboard="false" Name="Sheoldred's Edict" Annotation="0" />
+  <Cards CatID="147451" Quantity="1" Sideboard="false" Name="Sol Ring" Annotation="0" />
+  <Cards CatID="133540" Quantity="1" Sideboard="false" Name="Solemn Simulacrum" Annotation="0" />
+  <Cards CatID="102988" Quantity="1" Sideboard="false" Name="Sulfurous Springs" Annotation="0" />
+  <Cards CatID="63824" Quantity="1" Sideboard="false" Name="Supernatural Stamina" Annotation="0" />
+  <Cards CatID="34688" Quantity="1" Sideboard="false" Name="Bloodghast" Annotation="0" />
+  <Cards CatID="131133" Quantity="1" Sideboard="false" Name="Talisman of Indulgence" Annotation="0" />
+  <Cards CatID="93186" Quantity="1" Sideboard="false" Name="The Meathook Massacre" Annotation="0" />
+  <Cards CatID="142859" Quantity="1" Sideboard="false" Name="Umbral Collar Zealot" Annotation="0" />
+  <Cards CatID="134828" Quantity="1" Sideboard="false" Name="Undying Malice" Annotation="0" />
+  <Cards CatID="106521" Quantity="1" Sideboard="false" Name="Urabrask's Forge" Annotation="0" />
+  <Cards CatID="53250" Quantity="1" Sideboard="false" Name="Urborg, Tomb of Yawgmoth" Annotation="0" />
+  <Cards CatID="107705" Quantity="1" Sideboard="false" Name="Vampiric Tutor" Annotation="0" />
+  <Cards CatID="133720" Quantity="1" Sideboard="false" Name="Vengeful Bloodwitch" Annotation="0" />
+  <Cards CatID="44105" Quantity="1" Sideboard="false" Name="Blood Artist" Annotation="0" />
+  <Cards CatID="138335" Quantity="1" Sideboard="false" Name="Viscera Seer" Annotation="0" />
+  <Cards CatID="126237" Quantity="1" Sideboard="false" Name="Warren Soultrader" Annotation="0" />
+  <Cards CatID="59810" Quantity="1" Sideboard="false" Name="Westvale Abbey" Annotation="0" />
+  <Cards CatID="78620" Quantity="1" Sideboard="false" Name="Witch's Oven" Annotation="0" />
+  <Cards CatID="79370" Quantity="1" Sideboard="false" Name="Woe Strider" Annotation="0" />
+  <Cards CatID="72604" Quantity="1" Sideboard="false" Name="Yawgmoth, Thran Physician" Annotation="0" />
+  <Cards CatID="58401" Quantity="1" Sideboard="false" Name="Zulaport Cutthroat" Annotation="0" />
+  <Cards CatID="142375" Quantity="1" Sideboard="true" Name="Juri, Master of the Revue" Annotation="16777728" />
+</Deck>
+```
+
+### 2. .txt file export
+
+```
+60 CARD
+
+4 Deadly Dispute
+4 Drossforge Bridge
+2 Rakdos Carnarium
+4 First Day of Class
+4 Goblin Matron
+4 Ichor Wellspring
+1 Makeshift Munitions
+3 Duress
+4 Putrid Goblin
+4 Unearth
+1 Forgotten Cave
+4 Skirk Prospector
+2 Vault of Whispers
+4 Chromatic Star
+1 Faithless Looting
+1 Dark-Dweller Oracle
+4 Mountain
+4 Swamp
+1 Shred Memory
+1 Blood Fountain
+1 Pyromatics
+2 Great Furnace
+
+2 Introduction to Prophecy
+2 Warren Weirding
+1 Duress
+1 Krark-Clan Shaman
+3 Weather the Storm
+1 Masked Vandal
+4 Pyroblast
+1 Abrade
+
+```
+
+```
+COMMANDER
+
+1 Academy Manufactor
+1 Arcane Signet
+1 Arid Mesa
+1 Bastion of Remembrance
+1 Bitterbloom Bearer
+1 Bitterblossom
+1 Blazemire Verge
+1 Village Rites
+1 Blood Crypt
+10 Swamp
+1 Bloodstained Mire
+1 Bloodtithe Harvester
+1 Bojuka Bog
+1 Braids, Arisen Nightmare
+1 Callous Sell-Sword
+4 Mountain
+1 Cauldron Familiar
+1 Cavalier of Night
+1 Chainsaw
+1 Command Tower
+1 Corrupted Conviction
+1 Deadly Dispute
+1 Deflecting Swat
+1 Demonic Tutor
+1 Disciple of Bolas
+1 Dismember
+1 Dragonskull Summit
+1 Dreadhorde Invasion
+1 Erebos, Bleak-Hearted
+1 Evereth, Viceroy of Plunder
+1 Fable of the Mirror-Breaker
+1 Fabled Passage
+1 Fatal Push
+1 Final Vengeance
+1 Fling
+1 Fountainport
+1 Goblin Bombardment
+1 Goldspan Dragon
+1 Grave Pact
+1 Greedy Freebooter
+1 Haunted Ridge
+1 Jadar, Ghoulcaller of Nephalia
+1 Kazuul's Fury
+1 Krenko, Tin Street Kingpin
+1 Lord Skitter, Sewer King
+1 Mana Confluence
+1 Marionette Apprentice
+1 Marsh Flats
+1 Mayhem Devil
+1 Mirkwood Bats
+1 Carrion Feeder
+1 Nine-Lives Familiar
+1 Not Dead After All
+1 Ophiomancer
+1 Phyrexian Tower
+1 Priest of Forgotten Gods
+1 Rakdos Charm
+1 Rankle, Master of Pranks
+1 Raucous Theater
+1 Reassembling Skeleton
+1 Reflecting Pool
+1 Scavenger's Talent
+1 Sephiroth, Fabled SOLDIER
+1 Sheoldred
+1 Sheoldred, the Apocalypse
+1 Sheoldred's Edict
+1 Sol Ring
+1 Solemn Simulacrum
+1 Sulfurous Springs
+1 Supernatural Stamina
+1 Bloodghast
+1 Talisman of Indulgence
+1 The Meathook Massacre
+1 Umbral Collar Zealot
+1 Undying Malice
+1 Urabrask's Forge
+1 Urborg, Tomb of Yawgmoth
+1 Vampiric Tutor
+1 Vengeful Bloodwitch
+1 Blood Artist
+1 Viscera Seer
+1 Warren Soultrader
+1 Westvale Abbey
+1 Witch's Oven
+1 Woe Strider
+1 Yawgmoth, Thran Physician
+1 Zulaport Cutthroat
+
+1 Juri, Master of the Revue
+
+
+```
+
+### 3. .csv file export
+
+```
+60 CARD
+
+Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
+"Mountain",2,83561,Land,ZNR,277/280,No,No,0
+"Plains",3,83543,Land,ZNR,268/280,No,No,0
+"Swamp",1,83555,Land,ZNR,274/280,No,No,0
+"Nihil Spellbomb",1,38315,Common,SOM,187/249,No,No,0
+"Journey to Nowhere",2,34390,Common,ZEN,14/249,No,No,0
+"Kor Skyfisher",4,34444,Common,ZEN,23/249,No,No,0
+"Oliphaunt",2,112188,Common,LTR,139,No,No,0
+"Glint Hawk",4,38167,Common,SOM,10/249,No,No,0
+"Galvanic Blast",4,38203,Common,SOM,91/249,No,No,0
+"Bojuka Bog",1,35515,Common,WWK,132/145,No,No,0
+"Makeshift Munitions",1,65318,Uncommon,XLN,151/279,No,No,0
+"Omen of the Dead",1,79344,Common,THB,110/254,No,No,0
+"Lembas",3,112396,Common,LTR,243,No,No,0
+"Cleansing Wildfire",4,83247,Common,ZNR,137/280,No,No,0
+"Drossforge Bridge",2,90873,Common,MH2,246/303,No,No,0
+"Goldmire Bridge",2,90875,Common,MH2,247/303,No,No,0
+"Rustvale Bridge",4,90887,Common,MH2,253/303,No,No,0
+"Deadly Dispute",2,91690,Common,AFR,94/281,No,No,0
+"Experimental Synthesizer",4,97204,Common,NEO,138/302,No,No,0
+"Alpine Meadow",1,87839,Land,KHM,248/285,No,No,0
+"Chainer's Edict",2,53167,Common,VMA,108/325,No,No,0
+"Dawnbringer Cleric",2,91520,Common,AFR,9/281,No,No,0
+"Ancient Den",1,20015,Common,MRD,278/306,No,No,0
+"Lightning Bolt",2,37240,Common,M11,149/249,No,No,0
+"Sulfurous Mire",1,87891,Land,KHM,270/285,No,No,0
+"Great Furnace",1,20021,Common,MRD,282/306,No,No,0
+"Krark-Clan Shaman",1,19717,Common,MRD,98/306,No,No,0
+"Ichor Wellspring",2,39339,Common,MBS,110/155,No,No,0
+
+"Nihil Spellbomb",3,38315,Common,SOM,187/249,No,Yes,0
+"Destroy Evil",2,102510,Common,DMU,17/281,No,Yes,0
+"Revoke Existence",1,37999,Common,SOM,18/249,No,Yes,0
+"Krark-Clan Shaman",1,19717,Common,MRD,98/306,No,Yes,0
+"Cast into the Fire",3,112146,Common,LTR,118,No,Yes,0
+"Chainer's Edict",1,53167,Common,VMA,108/325,No,Yes,0
+"Gorilla Shaman",1,90983,Uncommon,MH2,280/303,No,Yes,0
+"Red Elemental Blast",2,67208,Uncommon,A25,147/249,No,Yes,0
+"Navigator's Compass",1,67915,Common,DAR,225/269,No,Yes,0
+
+
+```
+
+```
+COMMANDER
+
+Card Name,Quantity,ID #,Rarity,Set,Collector #,Premium,Sideboarded,Annotation
+"Academy Manufactor",1,90819,Rare,MH2,219/303,No,No,0
+"Arcane Signet",1,78722,Common,ELD,331,No,No,0
+"Arid Mesa",1,90869,Rare,MH2,244/303,No,No,0
+"Bastion of Remembrance",1,80155,Uncommon,IKO,73/274,No,No,0
+"Bitterbloom Bearer",1,146563,Mythic Rare,ECL,88,No,No,0
+"Bitterblossom",1,101622,Mythic Rare,2X2,69/331,No,No,0
+"Blazemire Verge",1,130643,Rare,DSK,256,No,No,0
+"Village Rites",1,81479,Common,M21,126/274,No,No,0
+"Blood Crypt",1,146917,Rare,ECL,262,No,No,0
+"Swamp",10,83555,Land,ZNR,274/280,No,No,0
+"Bloodstained Mire",1,126451,Rare,MH3,216,No,No,0
+"Bloodtithe Harvester",1,94832,Uncommon,VOW,232/277,No,No,0
+"Bojuka Bog",1,142435,Common,EOC,149,No,No,0
+"Braids, Arisen Nightmare",1,102644,Rare,DMU,84/281,No,No,0
+"Callous Sell-Sword",1,116788,Uncommon,WOE,221,No,No,0
+"Mountain",4,83561,Land,ZNR,277/280,No,No,0
+"Cauldron Familiar",1,78274,Uncommon,ELD,81/269,No,No,0
+"Cavalier of Night",1,73087,Mythic Rare,M20,94/280,No,No,0
+"Chainsaw",1,130387,Rare,DSK,128,No,No,0
+"Command Tower",1,78726,Common,ELD,333,No,No,0
+"Corrupted Conviction",1,124079,Common,OTJ,84,No,No,0
+"Deadly Dispute",1,91690,Common,AFR,94/281,No,No,0
+"Deflecting Swat",1,114655,Rare,CMM,214,No,No,0
+"Demonic Tutor",1,115399,Mythic Rare,CMM,150,No,No,0
+"Disciple of Bolas",1,138293,Rare,TDC,178,No,No,0
+"Dismember",1,57330,Uncommon,MM2,79/249,No,No,0
+"Dragonskull Summit",1,65534,Rare,XLN,252/279,No,No,0
+"Dreadhorde Invasion",1,71778,Rare,WAR,86/264,No,No,0
+"Erebos, Bleak-Hearted",1,79310,Mythic Rare,THB,93/254,No,No,0
+"Evereth, Viceroy of Plunder",1,132762,Promo,J25,41,No,No,0
+"Fable of the Mirror-Breaker",1,97210,Rare,NEO,141a/302,No,No,0
+"Fabled Passage",1,129749,Rare,BLB,252,No,No,0
+"Fatal Push",1,62689,Uncommon,AER,57/184,No,No,0
+"Final Vengeance",1,130329,Common,DSK,99,No,No,0
+"Fling",1,78378,Common,ELD,126/269,No,No,0
+"Fountainport",1,129751,Rare,BLB,253,No,No,0
+"Goblin Bombardment",1,90981,Rare,MH2,279/303,No,No,0
+"Goldspan Dragon",1,87613,Mythic Rare,KHM,139/285,No,No,0
+"Grave Pact",1,115429,Mythic Rare,CMM,165,No,No,0
+"Greedy Freebooter",1,118024,Common,LCI,109,No,No,0
+"Haunted Ridge",1,93536,Rare,MID,263/277,No,No,0
+"Jadar, Ghoulcaller of Nephalia",1,93176,Rare,MID,108/277,No,No,0
+"Kazuul's Fury",1,83265,Uncommon,ZNR,146a/280,No,No,0
+"Krenko, Tin Street Kingpin",1,71880,Rare,WAR,137/264,No,No,0
+"Lord Skitter, Sewer King",1,116510,Rare,WOE,97,No,No,0
+"Mana Confluence",1,86356,Promo,PRM,/1158,No,No,0
+"Marionette Apprentice",1,126217,Uncommon,MH3,100,No,No,0
+"Marsh Flats",1,90877,Rare,MH2,248/303,No,No,0
+"Mayhem Devil",1,72014,Uncommon,WAR,204/264,No,No,0
+"Mirkwood Bats",1,112100,Common,LTR,95,No,No,0
+"Carrion Feeder",1,60805,Common,EMA,84/249,No,No,0
+"Nine-Lives Familiar",1,133700,Rare,FDN,66,No,No,0
+"Not Dead After All",1,116518,Common,WOE,101,No,No,0
+"Ophiomancer",1,125963,Rare,MH3,276,No,No,0
+"Phyrexian Tower",1,126017,Mythic Rare,MH3,303,No,No,0
+"Priest of Forgotten Gods",1,71166,Rare,RNA,83/259,No,No,0
+"Rakdos Charm",1,142387,Uncommon,EOC,125,No,No,0
+"Rankle, Master of Pranks",1,78320,Mythic Rare,ELD,101/269,No,No,0
+"Raucous Theater",1,122024,Rare,MKM,266,No,No,0
+"Reassembling Skeleton",1,133390,Uncommon,FDN,182,No,No,0
+"Reflecting Pool",1,100754,Rare,CLB,358/361,No,No,0
+"Scavenger's Talent",1,129467,Rare,BLB,111,No,No,0
+"Sephiroth, Fabled SOLDIER",1,141159,Mythic Rare,FIN,115a,No,No,0
+"Sheoldred",1,110096,Mythic Rare,MOM,125a/291,No,No,0
+"Sheoldred, the Apocalypse",1,102690,Mythic Rare,DMU,107/281,No,No,0
+"Sheoldred's Edict",1,106431,Uncommon,ONE,108/271,No,No,0
+"Sol Ring",1,147451,Uncommon,TMC,59,No,No,0
+"Solemn Simulacrum",1,133540,Rare,FDN,257,No,No,0
+"Sulfurous Springs",1,102988,Rare,DMU,256/281,No,No,0
+"Supernatural Stamina",1,63824,Common,AKH,111/269,No,No,0
+"Bloodghast",1,34688,Rare,ZEN,83/249,No,No,0
+"Talisman of Indulgence",1,131133,Uncommon,DSC,254,No,No,0
+"The Meathook Massacre",1,93186,Mythic Rare,MID,112/277,No,No,0
+"Umbral Collar Zealot",1,142859,Uncommon,EOE,123,No,No,0
+"Undying Malice",1,134828,Common,FDN,528,No,No,0
+"Urabrask's Forge",1,106521,Rare,ONE,153/271,No,No,0
+"Urborg, Tomb of Yawgmoth",1,53250,Rare,M15,248/269,No,No,0
+"Vampiric Tutor",1,107705,Mythic Rare,DMR,108/261,No,No,0
+"Vengeful Bloodwitch",1,133720,Uncommon,FDN,76,No,No,0
+"Blood Artist",1,44105,Uncommon,AVR,86/244,No,No,0
+"Viscera Seer",1,138335,Common,TDC,199,No,No,0
+"Warren Soultrader",1,126237,Rare,MH3,110,No,No,0
+"Westvale Abbey",1,59810,Rare,SOI,281a/297,No,No,0
+"Witch's Oven",1,78620,Uncommon,ELD,237/269,No,No,0
+"Woe Strider",1,79370,Rare,THB,123/254,No,No,0
+"Yawgmoth, Thran Physician",1,72604,Mythic Rare,MH1,116/254,No,No,0
+"Zulaport Cutthroat",1,58401,Uncommon,BFZ,126/274,No,No,0
+
+"Juri, Master of the Revue",1,142375,Uncommon,EOC,119,No,Yes,16777728
+
+
+```
+
+## Magic Arena
+
+### 1. default export
+
+```
+60 CARD
+
+Deck
+4 Yawgmoth, Thran Physician (MH1) 116
+1 Swamp (LTR) 267
+4 Young Wolf (SIS) 58
+2 Forest (LTR) 271
+1 Blood Artist (JMP) 206
+1 Hapatra, Vizier of Poisons (AKR) 238
+4 Chord of Calling (M15) 172
+4 Delighted Halfling (LTR) 158
+4 Deathrite Shaman (RTR) 213
+2 Overgrown Tomb (GRN) 253
+1 Demonic Tutor (STA) 27
+4 Natural Order (STA) 54
+4 Orcish Bowmasters (LTR) 103
+3 Wooded Foothills (KTK) 249
+1 Polluted Delta (KTK) 239
+2 Windswept Heath (KTK) 248
+2 Boseiju, Who Endures (NEO) 266
+2 Blooming Marsh (KLR) 280
+1 Atraxa, Grand Unifier (ONE) 196
+1 Craterhoof Behemoth (JMP) 385
+1 Phyrexian Tower (JMP) 493
+2 Bloodstained Mire (KTK) 230
+1 Nurturing Peatland (MH1) 243
+4 Once Upon a Time (ELD) 169
+2 Badgermole Cub (TLA) 167
+2 Underground Mortuary (MKM) 271
+
+Sideboard
+3 Fatal Push (KLR) 84
+1 Pile On (MOM) 122
+1 Veil of Summer (M20) 198
+3 Thoughtseize (AKR) 127
+1 Phyrexian Revoker (BRR) 40
+1 Scavenging Ooze (M21) 204
+1 Haywire Mite (BRO) 199
+1 Skyfisher Spider (BRO) 221
+1 Sheoldred, the Apocalypse (DMU) 107
+2 Force of Vigor (OTP) 29
+
+```
+
+```
+COMMANDER
+
+Commander
+1 Juri, Master of the Revue (MUL) 111
+
+Deck
+1 Academy Manufactor (MH2) 219
+1 Arcane Signet (ELD) 331
+1 Arid Mesa (MH2) 244
+1 Bastion of Remembrance (IKO) 73
+1 Bitterbloom Bearer (ECL) 88
+1 Bitterblossom (MOR) 58
+1 Blazemire Verge (DSK) 256
+1 Blood Artist (JMP) 206
+1 Blood Crypt (RNA) 245
+1 Bloodghast (IMA) 82
+1 Bloodstained Mire (KTK) 230
+1 Bloodtithe Harvester (VOW) 232
+1 Bojuka Bog (WWK) 132
+1 Braids, Arisen Nightmare (DMU) 84
+1 Callous Sell-Sword (WOE) 221
+1 Cauldron Familiar (ELD) 81
+1 Cavalier of Night (M20) 94
+1 Chainsaw (DSK) 128
+1 Command Tower (ELD) 333
+1 Corrupted Conviction (MOM) 98
+1 Deadly Dispute (AFR) 94
+1 Deflecting Swat (TLE) 311
+1 Demonic Tutor (STA) 27
+1 Disciple of Bolas (M13) 88
+1 Dismember (SPG) 41
+1 Dragonskull Summit (XLN) 252
+1 Dreadhorde Invasion (WAR) 86
+1 Erebos, Bleak-Hearted (THB) 93
+1 Evereth, Viceroy of Plunder (J25) 41
+1 Fable of the Mirror-Breaker (NEO) 141
+1 Fabled Passage (ELD) 244
+1 Fatal Push (KLR) 84
+1 Final Vengeance (DSK) 99
+1 Fling (ELD) 126
+1 Fountainport (BLB) 253
+1 Goblin Bombardment (WOT) 43
+1 Goldspan Dragon (KHM) 139
+1 Grave Pact (WOT) 29
+1 Greedy Freebooter (LCI) 109
+1 Haunted Ridge (MID) 263
+1 Jadar, Ghoulcaller of Nephalia (MID) 108
+1 Kazuul's Fury (ZNR) 146
+1 Krenko, Tin Street Kingpin (WAR) 137
+1 Lord Skitter, Sewer King (WOE) 97
+1 Mana Confluence (JOU) 163
+1 Marionette Apprentice (MH3) 100
+1 Marsh Flats (MH2) 248
+1 Mayhem Devil (WAR) 204
+1 Mirkwood Bats (LTR) 95
+4 Mountain (KTK) 256
+1 Nine-Lives Familiar (FDN) 66
+1 Not Dead After All (WOE) 101
+1 Ophiomancer (CC2) 3
+1 Phyrexian Tower (JMP) 493
+1 Priest of Forgotten Gods (RNA) 83
+1 Rakdos Charm (C16) 218
+1 Rankle, Master of Pranks (ELD) 101
+1 Raucous Theater (MKM) 266
+1 Reassembling Skeleton (FDN) 182
+1 Reflecting Pool (SHM) 278
+1 Scavenger's Talent (BLB) 111
+1 Sephiroth, Fabled SOLDIER (FIN) 115
+1 Sheoldred (MOM) 125
+1 Sheoldred, the Apocalypse (DMU) 107
+1 Sheoldred's Edict (ONE) 108
+1 Solemn Simulacrum (M21) 239
+1 Sulfurous Springs (DMU) 256
+1 Supernatural Stamina (AKR) 126
+10 Swamp (KTK) 254
+1 Talisman of Indulgence (MRD) 255
+1 The Meathook Massacre (MID) 112
+1 Umbral Collar Zealot (EOE) 123
+1 Undying Malice (FDN) 528
+1 Urabrask's Forge (ONE) 153
+1 Urborg, Tomb of Yawgmoth (PIO) 118
+1 Vengeful Bloodwitch (FDN) 76
+1 Village Rites (M21) 126
+1 Warren Soultrader (MH3) 110
+1 Westvale Abbey (SIR) 275
+1 Witch's Oven (ELD) 237
+1 Woe Strider (THB) 123
+1 Yawgmoth, Thran Physician (MH1) 116
+1 Zulaport Cutthroat (BFZ) 126
+
+```

--- a/TASK.MD
+++ b/TASK.MD
@@ -1,6 +1,0 @@
-# Task
-
-Add support for exact card versions from text file:
-1. analyse common decklist formats (.dek, arena, etc...)
-2. edit string parser
-3. update collections API integration

--- a/TASK.MD
+++ b/TASK.MD
@@ -1,0 +1,6 @@
+# Task
+
+Add support for exact card versions from text file:
+1. analyse common decklist formats (.dek, arena, etc...)
+2. edit string parser
+3. update collections API integration

--- a/plans/plan-deckFormatDetection.checklist.md
+++ b/plans/plan-deckFormatDetection.checklist.md
@@ -1,0 +1,83 @@
+# Deck Format Detection Checklist
+
+## 1) Contracts and Types
+
+- [ ] Define matcher output type (`format`, `score`, `evidence`).
+- [ ] Define normalized parsed-card type (`quantity`, `groupId`, `rawLine`, `identifierCandidates`).
+- [ ] Define identifier candidate priority: `{mtgo_id}` (where valid) -> `{collector_number,set}` -> `{name,set}` -> `{name}`.
+
+## 2) Matchers (Low False Positives)
+
+- [ ] Implement matcher: MTGO `.dek` XML.
+- [ ] Implement matcher: MTGO `.csv`.
+- [ ] Implement matcher: Moxfield exact.
+- [ ] Implement matcher: Moxfield Arena copy.
+- [ ] Implement matcher: Arena default export.
+- [ ] Implement matcher: MTGGoldfish exact variants.
+- [ ] Implement matcher: MTGO/plain text.
+- [ ] Implement deterministic tie-break order: XML > CSV > Moxfield exact > Arena default > MTGGoldfish exact > plain text > heuristics.
+- [ ] Allow early stop only for deterministic signatures (XML prolog + `<Deck>`, exact CSV header).
+
+## 3) Parsers and Identifier Extraction
+
+- [ ] Create parser modules under `services/card-list/` (e.g., `listParsers.ts`, `identifierBuilders.ts`).
+- [ ] Parse section/group semantics (main, sideboard, commander) per format.
+- [ ] Extract Moxfield exact identifiers from `name (SET) collector`.
+- [ ] Extract Arena default identifiers from `(SET) number`.
+- [ ] Extract MTGGoldfish exact identifiers from `name [SET]` with treatment/foil suffix trimming.
+- [ ] Parse MTGO `.dek` XML card rows and sideboard flags.
+- [ ] Parse MTGO `.csv` rows and `Sideboarded` values.
+
+## 4) Orchestration Integration
+
+- [ ] Add a single orchestration entrypoint (e.g., `parseDecklistToRequests(decklist)`).
+- [ ] Integrate entrypoint into `app/api/collections/route.ts`.
+- [ ] Integrate entrypoint into `app/api/cards/route.ts`.
+- [ ] Preserve route limits and existing SSE behavior.
+
+## 5) Fetch/Fallback Logic
+
+- [ ] In `/api/collections`, request using best candidate tier first.
+- [ ] Retry unresolved `not_found` entries once with next fallback tier only.
+- [ ] Use stable request tokens/mapping instead of positional assumptions.
+- [ ] Remove old mock fallback behavior that conflicts with candidate-based flow in `/api/collections`.
+- [ ] Remove old mock fallback behavior that conflicts with candidate-based flow in `/api/cards`.
+- [ ] Mark cards still unresolved after one retry as `not_found` without more retries.
+
+## 6) Tests
+
+- [ ] Add matcher unit tests for all supported formats.
+- [ ] Add near-miss matcher tests to prevent false-positive wins.
+- [ ] Add parser unit tests for identifier extraction and candidate ordering.
+- [ ] Add parser unit tests for section/group assignment (main/sideboard/commander).
+- [ ] Add `/api/collections` integration tests for candidate fallback pass.
+- [ ] Add `/api/cards` integration tests for final name fallback path.
+- [ ] Verify no regression in maintenance mode, validation, and SSE complete events.
+
+## 7) Performance and Observability
+
+- [ ] Bound matcher scan to sampled non-empty/header lines.
+- [ ] Ensure detection/parsing remains O(n) and avoids regex backtracking traps.
+- [ ] Add non-prod logs: selected format, score, detection ms, retry count.
+- [ ] (Optional) Add timing analytics for detection/parsing stage.
+
+## 8) Documentation
+
+- [ ] Update `DECK-FORMATS.MD` with implemented behavior and limits.
+- [ ] Document identifier preference order and fallback behavior.
+- [ ] Document tie-break rules and deterministic-match early-stop policy.
+- [ ] Document known limitations around MTGO ID mapping assumptions.
+
+## 9) UI Guide (If In Scope)
+
+- [ ] Add lightweight guide route with supported format examples.
+- [ ] Include concise examples: Moxfield exact, MTGO `.dek`, Arena default, MTGGoldfish exact.
+- [ ] Add guide link in upload section.
+- [ ] Add guide link in footer.
+
+## 10) Final Validation
+
+- [ ] Run formatting.
+- [ ] Run unit tests.
+- [ ] Run build.
+- [ ] Smoke-test key decklist inputs in dev UI/API.

--- a/plans/plan-deckFormatDetection.prompt.md
+++ b/plans/plan-deckFormatDetection.prompt.md
@@ -1,0 +1,138 @@
+## Plan: Robust Deck Format Detection & Parsing
+
+Add a two-stage intake pipeline: (1) deterministic format detection with confidence scoring over sampled lines, then (2) format-specific parsing into ordered Scryfall identifier candidates (preferred + fallbacks). Keep API performance stable by doing lightweight regex/token checks only once per request and preserving existing batching/caching in `/api/collections` and `/api/cards`.
+
+**Steps**
+
+1. **Define canonical parser output contract**
+    - Create shared types for matcher scores and parser output to avoid parser-specific branching later.
+    - Output shape per card line should include: `quantity`, `groupId`, `rawLine`, and `identifierCandidates` ordered by reliability (e.g., `{set, collector_number}` first, then `{name, set}`, then `{name}`).
+    - Include a parse-level `format`, `score`, and `evidence` for observability.
+
+2. **Implement low-false-positive matcher layer** (_Phase A_)
+    - Implement one matcher per documented format in `services/card-list/listMatchers.ts`:
+        - Moxfield exact (`name (SET) collector` with commander/main/sideboard sections)
+        - Moxfield Arena copy (About/Name/Deck/Sideboard blocks)
+        - MTGO `.dek` XML
+        - MTGO `.csv`
+        - MTGO/plain text (`qty name` + optional `SIDEBOARD:`)
+        - Arena default export (`Deck` / `Commander` sections + `(SET) number` lines)
+        - MTGGoldfish exact variants (`[SET]`, optional `<treatment>`, optional `(F|FE)`)
+    - Use weighted signals (headers, delimiters, token patterns), not a single regex. Cap score to 10.
+    - Add tie-break policy for your chosen behavior (`always pick highest`): if equal score, choose the matcher with higher-priority deterministic signature (XML > CSV > structured headers > generic line format).
+    - Early stop only for deterministic signatures (e.g., XML prolog + `<Deck>`, CSV header exact match), not just any 10/10 from heuristic patterns.
+
+3. **Implement format-specific parsers producing Scryfall identifiers** (_depends on 1,2_)
+    - Add parser module(s) under `services/card-list/` (e.g., `listParsers.ts` + `identifierBuilders.ts`).
+    - For each format line, extract the best supported `/cards/collection` identifiers:
+        - Best: `{mtgo_id}` (only for MTGO .dek and .csv)
+        - Preferred when possible: `{collector_number, set}`
+        - Fallback: `{name, set}`
+        - Last fallback: `{name}`
+    - Preserve section semantics: main deck vs sideboard; commander position where represented as sideboard annotation.
+
+4. **Add an orchestration entrypoint and integrate APIs** (_depends on 3_)
+    - Introduce a single entrypoint (e.g., `parseDecklistToRequests(decklist)`) that runs matcher -> selected parser -> normalized card requests.
+    - Integrate this in:
+        - `app/api/collections/route.ts` (primary path)
+        - `app/api/cards/route.ts` (fallback/legacy path)
+    - Keep existing limits (150 unique in collections, 75 in cards) and SSE progress behavior unchanged.
+
+5. **Adjust fetch logic to consume identifier candidates efficiently** (_depends on 4_)
+    - For `/api/collections`: submit best candidate per card first; if `not_found`, retry unresolved cards in one additional pass with next fallback candidate tier. One single retry, collate all unresolved cards according to querty limits, do not retry indefinitely.
+    - clean up mock card fallback logic in `/api/collections` route to align with new candidate-based approach; remove any old fallback that doesn't fit the new contract. Missing cards after one retry should be marked `not_found` without further retries to protect latency.
+    - Ensure stable mapping by using a request token per entry (do not rely on response index when `not_found` exists).
+    - For `/api/cards` (named endpoint), use final `{name}` fallback only; avoid repeated per-card retries to protect latency.
+    - clean up mock card fallback logic in `/api/cards` route to align with new candidate-based approach; remove any old fallback that doesn't fit the new contract. Missing cards after one retry should be marked `not_found` without further retries to protect latency.
+6. **Add strong test coverage from DECK-FORMATS fixtures** (_parallelizable after 2/3 skeleton exists_)
+    - Add matcher tests for every supported format and near-miss anti-cases to prevent false positives.
+    - Add parser tests asserting identifier candidate ordering and extracted quantities/sections.
+    - Add integration tests for both API routes verifying:
+        - correct parser selected
+        - unresolved identifiers fallback path
+        - no regression in limit validation / maintenance handling / SSE complete events.
+
+7. **Performance guardrails and observability** (_depends on 4,5_)
+    - Keep matcher scan bounded (e.g., first 40 non-empty lines + header lines), O(n) string checks, no deep backtracking regex.
+    - Emit lightweight debug logs in non-production: chosen format, score, detection time, fallback retry count.
+    - Optional analytics timing metric for detection/parsing stage only.
+
+8. **Documentation update** (_depends on implementation complete_)
+    - Update `DECK-FORMATS.MD` and relevant README/testing docs to reflect exact behavior:
+        - supported inputs
+        - identifier preference order
+        - tie-break rules
+        - known limitations (MTGO CatID mapping uncertainty).
+
+9. **UI update** (_depends on implementation complete_)
+    - Create a new "guide" route in the app with examples of supported decklist formats and tips for best results for details. This can be a simple static page with formatted examples and common pitfalls.
+    - Example formats to include:
+        - Moxfield exact export
+        - MTGO `.dek` XML
+        - Arena default export
+    - MTGGoldfish exact variant
+    - Keep it lightweight and focused on helping users understand how to format their decklists for best parsing results.
+      -Provide only limited and effective guidance, a link to a full reference will be included later down the line.
+    - include succint decklist examples for the main supported formats, highlighting the key signals that enable correct parsing (e.g., section headers, collector numbers, set codes).
+    - add a link to this guide in the upload section UI and in the footer for easy access.
+
+**Relevant files**
+
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/services/card-list/listMatchers.ts` — implement format matchers and scoring.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/services/card-list/` (new parser/orchestrator files) — format-specific parsing + candidate identifier construction.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/app/api/collections/route.ts` — integrate parser output and collection fallback strategy.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/app/api/cards/route.ts` — integrate normalized parse output for named-fetch path.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/utils/decklist.ts` — keep as compatibility layer or slim delegator to new service.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/utils/__tests__/decklist.test.ts` — preserve existing behavior tests; add compatibility assertions if needed.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/app/api/collections/__tests__/route.test.ts` — add parser integration + fallback retry tests.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/app/api/cards/__tests__/route.test.ts` — add named fallback behavior tests.
+- `c:/Users/servo/Documents/personal/mtg-deck-to-png/DECK-FORMATS.MD` — align docs with implemented parsing behavior.
+
+**Format priority order for tie-breaking**
+
+1. MTGO `.dek` XML (most deterministic with prolog + `<Deck>` structure)
+2. MTGO `.csv` (deterministic header + comma-delimited structure)
+3. Moxfield exact (structured headers + `(SET) collector` format)
+4. Arena default export (section headers + `(SET) number` lines)
+5. MTGGoldfish exact variants (strong signals with `[SET]` + optional treatments)
+6. MTGO/plain text (generic line format with optional `SIDEBOARD:`)
+7. Other heuristics (e.g., presence of `Commander` section without strong signals may indicate Arena copy format, but with lower confidence than exact formats).
+
+**Grouping and section handling**
+
+- For formats with explicit section headers (e.g., `Commander`, `Sideboard`), use those to assign `groupId` and preserve commander/main/sideboard semantics.
+- For formats without explicit sections but with sideboard signals (e.g., `SIDEBOARD:` line), use that to split main vs sideboard and assign `groupId` accordingly.
+- For formats without any section signals, preserve current behaviour of treating empty lines as separators and assigning `groupId` based on line position (e.g., first contiguous block as main, second as sideboard).
+- For .dek XML, review the `sideboard` of each `<Cards>` element to assign `groupId` appropriately. `Sideboard="true"` results in `groupId` 1, otherwise `groupId` 0.
+- For .dek XML, a commander deck can be identified by the following signals:
+    - Presence of a single card with `Annotation="16777728"`.
+    - All cards have `Sideboard="false"`.
+- For MTGO .csv, use the presence of a `Sideboarded` column to determine if sideboard cards are present. If so, assign `groupId` 1 to rows where `Sideboarded=Yes`, `groupId` 0.
+
+**Format-specific card parsing details**
+
+- For Moxfield exact, extract `{collector_number, set}` from lines matching `name (SET) collector` format.
+- For Arena default export, extract `{collector_number, set}` from lines matching `(SET) number` format.
+- For MTGGoldfish exact variants, extract `{name, set}` from lines matching `name [SET]`. Trim optional treatment suffixes (e.g., `<prerelease>`, `<OTJ Special Guest>`), the `(F)` foil suffix.
+- For MTGO .dek XML, use the `catID` attribute to query Scryfall's `mtgo_id` field for the most reliable identifier. If not found, fallback to `{name}` from the `Name` attribute.
+- For MTGO .csv, extract `{mtgo_id}` from the `ID` column for the most reliable identifier. If not found, fallback to `{collector_number, set}` from the `Collector #` and `Set` columns.
+
+extract `{name}` from the `<Card>` element's `Name` attribute. If a validated mapping dataset is added later, this can be enhanced to include `{collector_number, set}` based on the `Multiverseid` or `MTGOCardID` attributes.
+
+**Verification**
+
+1. Unit: matcher tests prove each official format matches highest, and near-miss formats do not outrank correct parser.
+2. Unit: parser tests prove candidate identifier ordering for each input variant (`{set+collector}` > `{name+set}` > `{name}`).
+3. Integration: `/api/collections` returns cards for mixed exact/non-exact lists, including not_found fallback pass.
+4. Regression: existing `utils/decklist` tests still pass or are intentionally migrated with equivalent assertions.
+5. Performance: benchmark detection + parse on 100-card decklists remains low single-digit ms on local runs; no additional network round trips except unresolved fallback pass.
+
+**Decisions**
+
+- Confirmed requirement: use exact identifiers when possible; normalize to name-only when not.
+- Confirmed ambiguity policy: always choose highest score (with deterministic tie-break rules to avoid non-determinism).
+- Included scope: all formats in `DECK-FORMATS.MD`.
+- Excluded scope for now: authoritative MTGO CatID -> Scryfall `mtgo_id` mapping unless verified dataset/source is added.
+- "exact versions" should fallback permissively to best-effort parsing rather than failing outright, to maximize successful matches while still preferring exact when available.
+- keep server-only logs for format detection and parsing details to aid troubleshooting without exposing complexity to users
+- reorganize `utils/decklist` to delegate to new service while preserving existing API for compatibility; reorganize logic into `services/card-list/` for clearer separation of concerns and easier testing when appropriate.

--- a/services/card-list/identifierBuilders.ts
+++ b/services/card-list/identifierBuilders.ts
@@ -1,0 +1,1 @@
+// builder functions that are used to build the card identifiers from the parsed decklist

--- a/services/card-list/listMatchers.ts
+++ b/services/card-list/listMatchers.ts
@@ -1,0 +1,1 @@
+// matcher functions that are used to identify the decklist format

--- a/services/card-list/listParsers.ts
+++ b/services/card-list/listParsers.ts
@@ -1,0 +1,1 @@
+// parser functions that are used to parse the decklist into a standardized format


### PR DESCRIPTION
Add support for exact card versions from text file:
1. analyse common decklist formats (.dek, arena, etc...)
2. edit string parser
3. update collections API integration