### PR TITLE
Group management and group labels

### DIFF
--- a/TASK.MD
+++ b/TASK.MD
@@ -1,0 +1,9 @@
+# Task
+
+add group management UX and fixed group label option.
+
+1. add a "groups" tab to the configure section. The tab should show a table with the cards arranged in groups
+2. group table columns: count, name, set, card number, artist
+3. Add a select ontop of each group that allows to assign a group label: Main deck, Sideboard, Maybeboard, Commander, etc..
+4. Create static overlays for group labels
+5. Integrate label positioning and scaling logic


### PR DESCRIPTION
Add group management UX and fixed group label option.

1. add a "groups" tab to the configure section. The tab should show an accordion for each group
2. each accordion button contains: group name (a select for the group label), card count, "display label" checkbox
3. each accordion modal contains a table with the cards in the group
4. group table columns: count, name, version (set + card number, artist
5. group labels are english-only, fixed options: Main deck, Sideboard, Maybeboard, Commander, etc..
6. Create static overlays for group labels
7. Integrate label positioning and scaling logic